### PR TITLE
Add property to only output pretransform with transformers present

### DIFF
--- a/src/main/java/net/minecraft/launchwrapper/LaunchClassLoader.java
+++ b/src/main/java/net/minecraft/launchwrapper/LaunchClassLoader.java
@@ -48,6 +48,8 @@ public class LaunchClassLoader extends URLClassLoader {
             DEBUG && Boolean.parseBoolean(System.getProperty("legacy.debugClassLoadingFiner", "false"));
     private static final boolean DEBUG_SAVE =
             DEBUG && Boolean.parseBoolean(System.getProperty("legacy.debugClassLoadingSave", "false"));
+    private static final boolean DEBUG_SLIM =
+            DEBUG && Boolean.parseBoolean(System.getProperty("legacy.debugClassLoadingSlim", "false"));
     private static File tempFolder = null;
 
     public LaunchClassLoader(URL[] sources) {
@@ -313,7 +315,9 @@ public class LaunchClassLoader extends URLClassLoader {
             byte[] preTransformHash = EMPTY_BYTE_ARRAY;
             if (hashers != null && basicClass != null) {
                 preTransformHash = hashers.digest(basicClass);
-                saveTransformedClass(basicClass, transformedName + "_000_pretransform");
+                if (!DEBUG_SLIM || (transformers != null && !transformers.isEmpty())) {
+                    saveTransformedClass(basicClass, transformedName + "_000_pretransform");
+                }
             }
             LogWrapper.finest(
                     "Beginning transform of [{} ({})] Start Length: {}",

--- a/src/main/java/net/minecraft/launchwrapper/LaunchClassLoader.java
+++ b/src/main/java/net/minecraft/launchwrapper/LaunchClassLoader.java
@@ -359,11 +359,17 @@ public class LaunchClassLoader extends URLClassLoader {
                     transformedName,
                     (basicClass == null ? 0 : basicClass.length));
         } else {
+            byte[] originalClass = null;
+            if (DEBUG_SLIM) {
+                originalClass = Arrays.copyOf(basicClass, basicClass.length);
+            }
             for (final IClassTransformer transformer : transformers) {
                 basicClass = transformer.transform(name, transformedName, basicClass);
             }
             if (DEBUG_SAVE) {
-                saveTransformedClass(basicClass, transformedName);
+                if (!DEBUG_SLIM || !Arrays.equals(originalClass, basicClass)) {
+                    saveTransformedClass(basicClass, transformedName);
+                }
             }
         }
         return basicClass;


### PR DESCRIPTION
If specified, doesn't output pretransform class files unless transformers are to be applied. Helps minimize the number of classes to sift through in debugging in some cases